### PR TITLE
v1.1 — Quick Wins & Polish

### DIFF
--- a/app/components/Sidebar.jsx
+++ b/app/components/Sidebar.jsx
@@ -55,9 +55,9 @@ export default function Sidebar({
   }, [isOpen]);
 
   const sidebarContent = (
-    <nav className="flex flex-col h-full">
+    <nav className="h-full overflow-y-auto">
       {/* Subject List */}
-      <div className="flex-1 overflow-y-auto py-2">
+      <div className="py-2">
         <div className="flex items-center justify-between px-3 py-1.5">
           <span className="text-[11px] font-semibold uppercase tracking-wider text-text-muted">
             Modules

--- a/app/components/TopBar.jsx
+++ b/app/components/TopBar.jsx
@@ -7,7 +7,7 @@ import { searchModules, searchFormulas } from "~/data";
 
 export default function TopBar({ progress = 0, onToggleSidebar }) {
   const { isDark, toggleTheme } = useTheme();
-  const { user, signOut } = useAuth();
+  const { user } = useAuth();
   const navigate = useNavigate();
   const [query, setQuery] = useState("");
   const [isOpen, setIsOpen] = useState(false);
@@ -179,17 +179,9 @@ export default function TopBar({ progress = 0, onToggleSidebar }) {
         </button>
 
         {user && (
-          <>
-            <span className="text-xs text-text-muted hidden sm:inline truncate max-w-[120px]">
-              {user.displayName || user.email}
-            </span>
-            <button
-              onClick={signOut}
-              className="text-xs text-text-secondary hover:text-danger transition-colors font-medium"
-            >
-              Sign Out
-            </button>
-          </>
+          <span className="text-xs text-text-muted hidden sm:inline truncate max-w-[120px]">
+            {user.displayName || user.email}
+          </span>
         )}
 
       </div>

--- a/app/routes.js
+++ b/app/routes.js
@@ -3,6 +3,8 @@ import { index, layout, route } from "@react-router/dev/routes";
 export default [
   index("routes/home.jsx"),
   route("login", "routes/login.jsx"),
+  route("terms", "routes/terms.jsx"),
+  route("privacy", "routes/privacy.jsx"),
   layout("components/ProtectedLayout.jsx", [
     layout("routes/dashboard.jsx", [
       route("dashboard", "routes/dashboard-index.jsx"),

--- a/app/routes/privacy.jsx
+++ b/app/routes/privacy.jsx
@@ -1,0 +1,183 @@
+import { Link } from "react-router";
+import { ArrowLeft } from "lucide-react";
+
+export default function Privacy() {
+  return (
+    <div className="min-h-screen bg-surface">
+      <nav className="sticky top-0 z-50 bg-surface/80 backdrop-blur-md border-b border-border">
+        <div className="max-w-4xl mx-auto px-6 h-16 flex items-center">
+          <Link
+            to="/dashboard"
+            className="flex items-center gap-2 text-text-secondary hover:text-text-primary transition-colors text-sm"
+          >
+            <ArrowLeft className="w-4 h-4" />
+            Back to Dashboard
+          </Link>
+        </div>
+      </nav>
+
+      <main className="max-w-4xl mx-auto px-6 py-12">
+        <h1 className="text-3xl font-bold text-text-primary mb-2">
+          Privacy Policy
+        </h1>
+        <p className="text-text-muted text-sm mb-10">
+          Last updated: February 22, 2026
+        </p>
+
+        <div className="space-y-8 text-text-secondary text-sm leading-relaxed">
+          <section>
+            <h2 className="text-lg font-semibold text-text-primary mb-3">
+              1. Overview
+            </h2>
+            <p>
+              CFA Master ("the Service") respects your privacy. This policy
+              explains what data we collect, how we use it, and your rights
+              regarding that data.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="text-lg font-semibold text-text-primary mb-3">
+              2. Data We Collect
+            </h2>
+            <p>
+              <strong className="text-text-primary">
+                If you use the Service without signing in:
+              </strong>{" "}
+              We do not collect any personal data. No cookies, no tracking, no
+              analytics.
+            </p>
+            <p className="mt-3">
+              <strong className="text-text-primary">
+                If you sign in with Google or email/password:
+              </strong>{" "}
+              We store the following through Firebase Authentication and
+              Firestore:
+            </p>
+            <ul className="list-disc pl-6 mt-2 space-y-1">
+              <li>Your display name and email address (from your auth provider)</li>
+              <li>Module completion progress</li>
+              <li>Quiz scores and attempt history</li>
+              <li>Theme preference (dark/light mode)</li>
+            </ul>
+          </section>
+
+          <section>
+            <h2 className="text-lg font-semibold text-text-primary mb-3">
+              3. How We Use Your Data
+            </h2>
+            <p>Your data is used solely to:</p>
+            <ul className="list-disc pl-6 mt-2 space-y-1">
+              <li>Authenticate you and maintain your session</li>
+              <li>Save and sync your study progress across devices</li>
+              <li>Persist your theme preference</li>
+            </ul>
+            <p className="mt-3">
+              We do not sell, share, or transfer your personal data to any third
+              parties. We do not use your data for advertising, marketing, or
+              profiling.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="text-lg font-semibold text-text-primary mb-3">
+              4. Third-Party Services
+            </h2>
+            <p>The Service uses the following third-party services:</p>
+            <ul className="list-disc pl-6 mt-2 space-y-1">
+              <li>
+                <strong className="text-text-primary">
+                  Firebase Authentication
+                </strong>{" "}
+                — for user sign-in (Google OAuth and email/password)
+              </li>
+              <li>
+                <strong className="text-text-primary">
+                  Cloud Firestore
+                </strong>{" "}
+                — for storing user progress and preferences
+              </li>
+              <li>
+                <strong className="text-text-primary">
+                  Cloudflare Workers
+                </strong>{" "}
+                — for hosting and serving the application
+              </li>
+            </ul>
+            <p className="mt-3">
+              These services have their own privacy policies. We encourage you
+              to review them.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="text-lg font-semibold text-text-primary mb-3">
+              5. Data Storage & Security
+            </h2>
+            <p>
+              Your data is stored in Google Cloud Firestore servers. All data
+              transmission is encrypted via HTTPS. We use Firebase security
+              rules to ensure users can only access their own data.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="text-lg font-semibold text-text-primary mb-3">
+              6. Data Retention & Deletion
+            </h2>
+            <p>
+              Your data is retained as long as your account exists. You can
+              request deletion of your account and all associated data by
+              opening an issue on our GitHub repository. Upon request, we will
+              delete your Firestore documents and Firebase Authentication
+              record.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="text-lg font-semibold text-text-primary mb-3">
+              7. Children's Privacy
+            </h2>
+            <p>
+              The Service is not directed at children under 13. We do not
+              knowingly collect personal information from children under 13. If
+              you believe a child has provided us with personal data, please
+              contact us so we can delete it.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="text-lg font-semibold text-text-primary mb-3">
+              8. Changes to This Policy
+            </h2>
+            <p>
+              We may update this Privacy Policy from time to time. Changes will
+              be posted on this page with an updated "Last updated" date.
+              Continued use of the Service after changes constitutes acceptance
+              of the updated policy.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="text-lg font-semibold text-text-primary mb-3">
+              9. Contact
+            </h2>
+            <p>
+              If you have any questions about this Privacy Policy or want to
+              request data deletion, please open an issue on our{" "}
+              <a
+                href="https://github.com/SALORG/cfa-app"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-accent hover:underline"
+              >
+                GitHub repository
+              </a>
+              .
+            </p>
+          </section>
+        </div>
+      </main>
+    </div>
+  );
+}

--- a/app/routes/terms.jsx
+++ b/app/routes/terms.jsx
@@ -1,0 +1,164 @@
+import { Link } from "react-router";
+import { ArrowLeft } from "lucide-react";
+
+export default function Terms() {
+  return (
+    <div className="min-h-screen bg-surface">
+      <nav className="sticky top-0 z-50 bg-surface/80 backdrop-blur-md border-b border-border">
+        <div className="max-w-4xl mx-auto px-6 h-16 flex items-center">
+          <Link
+            to="/dashboard"
+            className="flex items-center gap-2 text-text-secondary hover:text-text-primary transition-colors text-sm"
+          >
+            <ArrowLeft className="w-4 h-4" />
+            Back to Dashboard
+          </Link>
+        </div>
+      </nav>
+
+      <main className="max-w-4xl mx-auto px-6 py-12">
+        <h1 className="text-3xl font-bold text-text-primary mb-2">
+          Terms & Conditions
+        </h1>
+        <p className="text-text-muted text-sm mb-10">
+          Last updated: February 22, 2026
+        </p>
+
+        <div className="space-y-8 text-text-secondary text-sm leading-relaxed">
+          <section>
+            <h2 className="text-lg font-semibold text-text-primary mb-3">
+              1. Acceptance of Terms
+            </h2>
+            <p>
+              By accessing and using CFA Master ("the Service"), you agree to be
+              bound by these Terms & Conditions. If you do not agree with any
+              part of these terms, you must not use the Service.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="text-lg font-semibold text-text-primary mb-3">
+              2. Description of Service
+            </h2>
+            <p>
+              CFA Master is a free, community-built study tool for CFA Level I
+              exam preparation. The Service provides cheat sheets, flashcards,
+              quizzes, practice exams, formula sheets, and progress tracking.
+              The Service is provided "as is" and is not affiliated with,
+              endorsed by, or connected to the CFA Institute in any way.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="text-lg font-semibold text-text-primary mb-3">
+              3. User Accounts
+            </h2>
+            <p>
+              You may use the Service without creating an account. If you choose
+              to sign in via Google or email/password, you are responsible for
+              maintaining the security of your account credentials. You agree to
+              provide accurate information and to not share your account with
+              others.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="text-lg font-semibold text-text-primary mb-3">
+              4. Acceptable Use
+            </h2>
+            <p>You agree not to:</p>
+            <ul className="list-disc pl-6 mt-2 space-y-1">
+              <li>
+                Use the Service for any unlawful purpose or in violation of any
+                applicable laws
+              </li>
+              <li>
+                Attempt to gain unauthorized access to the Service or its
+                related systems
+              </li>
+              <li>
+                Reproduce, distribute, or commercially exploit any content from
+                the Service without permission
+              </li>
+              <li>
+                Interfere with or disrupt the integrity or performance of the
+                Service
+              </li>
+            </ul>
+          </section>
+
+          <section>
+            <h2 className="text-lg font-semibold text-text-primary mb-3">
+              5. Intellectual Property
+            </h2>
+            <p>
+              All content, design, and code comprising the Service are the
+              property of CFA Master or its contributors. CFA&reg; and
+              Chartered Financial Analyst&reg; are registered trademarks owned
+              by the CFA Institute. CFA Master is not affiliated with or
+              endorsed by the CFA Institute.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="text-lg font-semibold text-text-primary mb-3">
+              6. Disclaimer of Warranties
+            </h2>
+            <p>
+              The Service is provided on an "as is" and "as available" basis
+              without warranties of any kind, either express or implied. We do
+              not guarantee that the study content is complete, accurate, or
+              up-to-date. The Service is a supplementary study aid and should
+              not be your sole source of exam preparation. We make no guarantees
+              regarding exam outcomes.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="text-lg font-semibold text-text-primary mb-3">
+              7. Limitation of Liability
+            </h2>
+            <p>
+              To the fullest extent permitted by law, CFA Master and its
+              contributors shall not be liable for any indirect, incidental,
+              special, consequential, or punitive damages, including but not
+              limited to loss of data, exam failure, or any other loss arising
+              from your use of the Service.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="text-lg font-semibold text-text-primary mb-3">
+              8. Changes to Terms
+            </h2>
+            <p>
+              We reserve the right to modify these terms at any time. Changes
+              will be effective immediately upon posting to the Service.
+              Continued use of the Service after changes constitutes acceptance
+              of the updated terms.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="text-lg font-semibold text-text-primary mb-3">
+              9. Contact
+            </h2>
+            <p>
+              If you have any questions about these Terms & Conditions, please
+              open an issue on our{" "}
+              <a
+                href="https://github.com/SALORG/cfa-app"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-accent hover:underline"
+              >
+                GitHub repository
+              </a>
+              .
+            </p>
+          </section>
+        </div>
+      </main>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- **#18** Remove Sign Out button from top bar (logout remains in sidebar)
- **#19** Make entire sidebar scrollable (modules, quick links, and legal/logout all scroll together)
- **#16** Add Terms & Conditions page with full legal content (9 sections)
- **#17** Add Privacy Policy page with data collection and third-party service details (9 sections)

## Test plan
- [ ] Verify Sign Out button is gone from the top bar, user display name still shows
- [ ] Verify sidebar scrolls as one unit when content overflows (especially on mobile)
- [ ] Visit `/terms` and confirm all 9 sections render correctly
- [ ] Visit `/privacy` and confirm all 9 sections render correctly
- [ ] Verify sidebar links to Terms & Privacy still work
- [ ] Test on mobile viewport sizes

Closes #16, #17, #18, #19

🤖 Generated with [Claude Code](https://claude.com/claude-code)