### PR TITLE
Add content gating for freemium model

### DIFF
--- a/app/components/LockedOverlay.jsx
+++ b/app/components/LockedOverlay.jsx
@@ -1,0 +1,22 @@
+import { Link } from "react-router";
+
+export default function LockedOverlay({ title = "Premium Content" }) {
+  return (
+    <div className="p-6 max-w-lg mx-auto mt-20 text-center">
+      <div className="bg-surface-secondary rounded-2xl border border-border p-10">
+        <span className="text-5xl mb-4 block">🔒</span>
+        <h2 className="text-2xl font-bold text-text-primary mb-2">{title}</h2>
+        <p className="text-text-secondary mb-6">
+          This content is available with a premium subscription. Upgrade to
+          unlock all modules, formulas, connections, and practice exams.
+        </p>
+        <Link
+          to="/dashboard"
+          className="inline-flex items-center gap-2 px-6 py-3 bg-accent text-white rounded-xl font-semibold hover:bg-accent-hover transition-colors"
+        >
+          Back to Dashboard
+        </Link>
+      </div>
+    </div>
+  );
+}

--- a/app/components/Sidebar.jsx
+++ b/app/components/Sidebar.jsx
@@ -1,6 +1,6 @@
 import { useState, useEffect } from "react";
 import { Link } from "react-router";
-import { subjects } from "~/data";
+import { subjects, isContentLocked } from "~/data";
 import { useAuth } from "~/context/AuthContext";
 
 const quickLinks = [
@@ -77,13 +77,14 @@ export default function Sidebar({
         {subjects.map((subject) => {
           const isExpanded = expandedSubjects.has(subject.id);
           const completedCount = getSubjectProgress(subject);
+          const locked = isContentLocked(subject.id);
 
           return (
             <div key={subject.id}>
               {/* Subject Header */}
               <button
                 onClick={() => toggleSubject(subject.id)}
-                className="w-full flex items-center gap-2 px-3 py-2.5 text-left hover:bg-surface transition-colors"
+                className={`w-full flex items-center gap-2 px-3 py-2.5 text-left hover:bg-surface transition-colors ${locked ? "opacity-60" : ""}`}
                 style={{ borderLeft: `3px solid ${subject.color}` }}
               >
                 <span className="text-base" role="img" aria-hidden="true">
@@ -92,9 +93,13 @@ export default function Sidebar({
                 <span className="flex-1 text-sm font-medium text-text-primary truncate" title={subject.name}>
                   {subject.name}
                 </span>
-                <span className="text-xs text-text-secondary tabular-nums">
-                  {completedCount}/{subject.modules.length}
-                </span>
+                {locked ? (
+                  <span className="text-xs text-text-muted">🔒</span>
+                ) : (
+                  <span className="text-xs text-text-secondary tabular-nums">
+                    {completedCount}/{subject.modules.length}
+                  </span>
+                )}
                 <span className="text-xs text-text-secondary transition-transform duration-200">
                   {isExpanded ? "\u25B2" : "\u25BC"}
                 </span>
@@ -114,15 +119,18 @@ export default function Sidebar({
                         to={`/dashboard/${subject.id}/${mod.id}`}
                         onClick={onClose}
                         className={`flex items-center gap-2 pl-8 pr-3 py-1.5 text-sm transition-colors ${
-                          isActive
-                            ? "text-accent bg-accent/10 font-medium"
-                            : "text-text-secondary hover:text-text-primary hover:bg-surface"
+                          locked
+                            ? "text-text-muted opacity-50"
+                            : isActive
+                              ? "text-accent bg-accent/10 font-medium"
+                              : "text-text-secondary hover:text-text-primary hover:bg-surface"
                         }`}
                       >
                         <span className="text-xs text-text-secondary w-5 shrink-0 tabular-nums">
                           {mod.number}.
                         </span>
                         <span className="truncate" title={mod.title}>{mod.title}</span>
+                        {locked && <span className="text-xs ml-auto shrink-0">🔒</span>}
                       </Link>
                     );
                   })}
@@ -140,10 +148,11 @@ export default function Sidebar({
             key={link.to}
             to={link.to}
             onClick={onClose}
-            className="flex items-center gap-2 px-2 py-1.5 text-sm text-text-secondary hover:text-text-primary hover:bg-surface rounded-md transition-colors"
+            className="flex items-center gap-2 px-2 py-1.5 text-sm text-text-secondary hover:text-text-primary hover:bg-surface rounded-md transition-colors opacity-60"
           >
             <span className="w-5 text-center text-xs">{link.icon}</span>
             <span>{link.label}</span>
+            <span className="text-xs ml-auto">🔒</span>
           </Link>
         ))}
       </div>

--- a/app/data/index.js
+++ b/app/data/index.js
@@ -10,6 +10,13 @@ import portfolio from "./portfolio.json";
 import ethics from "./ethics.json";
 import consolidated from "./consolidated.json";
 
+// The only subject available to free users
+export const FREE_SUBJECT_ID = "quants";
+
+export function isContentLocked(subjectId) {
+  return subjectId !== FREE_SUBJECT_ID;
+}
+
 export const subjects = [
   quants,
   economics,

--- a/app/routes/dashboard-connections.jsx
+++ b/app/routes/dashboard-connections.jsx
@@ -1,7 +1,9 @@
 import { Link } from "react-router";
 import { consolidated } from "~/data";
+import LockedOverlay from "~/components/LockedOverlay";
 
 export default function DashboardConnections() {
+  return <LockedOverlay title="Inter-Subject Connections" />;
   const connections = consolidated.interSubjectConnections?.connections || [];
 
   return (

--- a/app/routes/dashboard-formulas.jsx
+++ b/app/routes/dashboard-formulas.jsx
@@ -1,7 +1,9 @@
 import { Link } from "react-router";
 import { consolidated } from "~/data";
+import LockedOverlay from "~/components/LockedOverlay";
 
 export default function DashboardFormulas() {
+  return <LockedOverlay title="Master Formulas" />;
   const { masterFormulas } = consolidated;
 
   if (!masterFormulas?.sections) {

--- a/app/routes/dashboard-index.jsx
+++ b/app/routes/dashboard-index.jsx
@@ -1,5 +1,5 @@
 import { Link } from "react-router";
-import { subjects, allModules } from "~/data";
+import { subjects, allModules, isContentLocked } from "~/data";
 import { useDashboardContext } from "./dashboard";
 
 export default function DashboardIndex() {
@@ -102,6 +102,7 @@ export default function DashboardIndex() {
       <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4 mb-8">
         {subjects.map((subject) => {
           const subjectModules = subject.modules;
+          const locked = isContentLocked(subject.id);
           const subjectCompleted = subjectModules.filter(
             (m) => progress[`${subject.id}__${m.id}`]
           ).length;
@@ -114,7 +115,7 @@ export default function DashboardIndex() {
             <Link
               key={subject.id}
               to={`/dashboard/${subject.id}/${subject.modules[0]?.id}`}
-              className="group block bg-surface-secondary rounded-xl p-5 border border-border hover:border-accent/50 transition-all hover:shadow-lg"
+              className={`group block bg-surface-secondary rounded-xl p-5 border border-border transition-all ${locked ? "opacity-60" : "hover:border-accent/50 hover:shadow-lg"}`}
             >
               <div className="flex items-start justify-between mb-3">
                 <div className="flex items-center gap-3">
@@ -133,6 +134,7 @@ export default function DashboardIndex() {
                     </p>
                   </div>
                 </div>
+                {locked && <span className="text-lg">🔒</span>}
               </div>
 
               {/* Progress bar */}
@@ -163,18 +165,21 @@ export default function DashboardIndex() {
           icon="📐"
           title="Master Formulas"
           desc="All key formulas in one place"
+          locked
         />
         <QuickLink
           to="/dashboard/connections"
           icon="🔗"
           title="Inter-Subject Connections"
           desc="See how topics relate"
+          locked
         />
         <QuickLink
           to="/dashboard/practice-exam"
           icon="📝"
           title="Practice Exam"
           desc="Full 180-question mock exam"
+          locked
         />
       </div>
     </div>
@@ -190,19 +195,20 @@ function StatCard({ label, value, color = "text-text-primary" }) {
   );
 }
 
-function QuickLink({ to, icon, title, desc }) {
+function QuickLink({ to, icon, title, desc, locked }) {
   return (
     <Link
       to={to}
-      className="flex items-center gap-4 bg-surface-secondary rounded-xl p-4 border border-border hover:border-accent/50 transition-all hover:shadow-lg group"
+      className={`flex items-center gap-4 bg-surface-secondary rounded-xl p-4 border border-border transition-all group ${locked ? "opacity-60" : "hover:border-accent/50 hover:shadow-lg"}`}
     >
       <span className="text-3xl">{icon}</span>
-      <div>
+      <div className="flex-1">
         <h3 className="font-semibold text-text-primary group-hover:text-accent transition-colors">
           {title}
         </h3>
         <p className="text-sm text-text-muted">{desc}</p>
       </div>
+      {locked && <span className="text-lg">🔒</span>}
     </Link>
   );
 }

--- a/app/routes/dashboard-module.jsx
+++ b/app/routes/dashboard-module.jsx
@@ -3,12 +3,13 @@ import { useParams, Link } from "react-router";
 import { doc, updateDoc, arrayUnion, Timestamp } from "firebase/firestore/lite";
 import { db } from "~/lib/firebase";
 import { useAuth } from "~/context/AuthContext";
-import { getSubject, getModule, getAdjacentModules } from "~/data";
+import { getSubject, getModule, getAdjacentModules, isContentLocked } from "~/data";
 import { useDashboardContext } from "./dashboard";
 import CheatSheet from "~/components/CheatSheet";
 import MindMap from "~/components/MindMap";
 import FlashCards from "~/components/FlashCards";
 import Quiz from "~/components/Quiz";
+import LockedOverlay from "~/components/LockedOverlay";
 
 const TABS = [
   { id: "cheatsheet", label: "Cheat Sheet", icon: "📋" },
@@ -26,6 +27,10 @@ export default function DashboardModule() {
   const subject = getSubject(subjectId);
   const mod = getModule(subjectId, moduleId);
   const { prev, next } = getAdjacentModules(subjectId, moduleId);
+
+  if (isContentLocked(subjectId)) {
+    return <LockedOverlay title="Premium Module" />;
+  }
 
   if (!subject || !mod) {
     return (

--- a/app/routes/dashboard-practice-exam.jsx
+++ b/app/routes/dashboard-practice-exam.jsx
@@ -2,10 +2,13 @@ import { useState } from "react";
 import { Link } from "react-router";
 import { consolidated } from "~/data";
 import Quiz from "~/components/Quiz";
+import LockedOverlay from "~/components/LockedOverlay";
 
 export default function DashboardPracticeExam() {
   const examData = consolidated.practiceExam;
   const [started, setStarted] = useState(false);
+
+  return <LockedOverlay title="Practice Exam" />;
 
   if (!examData?.questions) {
     return (

--- a/app/routes/home.jsx
+++ b/app/routes/home.jsx
@@ -63,7 +63,7 @@ const proofPoints = [
   { icon: BookOpen, label: "Complete 2026 Curriculum" },
   { icon: Target, label: "59 Modules Covered" },
   { icon: GraduationCap, label: "Exam-Day Ready" },
-  { icon: Zap, label: "100% Free" },
+  { icon: Zap, label: "Start Instantly" },
 ];
 
 export default function Home() {
@@ -92,7 +92,7 @@ export default function Home() {
               to="/dashboard"
               className="flex items-center gap-2 px-4 py-2 bg-accent text-white rounded-lg font-medium hover:bg-accent-hover transition-colors text-sm"
             >
-              Start Free
+              Get Started
               <ArrowRight className="w-4 h-4" />
             </Link>
           </div>
@@ -108,21 +108,21 @@ export default function Home() {
             </p>
             <h1 className="text-4xl sm:text-5xl lg:text-6xl font-extrabold text-text-primary mb-6 leading-tight">
               Pass CFA Level I{" "}
-              <span className="text-accent">with Free Study Tools</span>
+              <span className="text-accent">with Smart Study Tools</span>
             </h1>
             <p className="text-lg text-text-secondary max-w-xl mb-4">
               {subjects.length} subjects, {allModules.length} modules, 246 formulas,
               and a full 180-question mock exam — everything you need in one dashboard.
             </p>
             <p className="text-text-muted text-sm mb-8">
-              No credit card. No paywall. Just study.
+              Start studying now. Sign in to save your progress.
             </p>
             <div className="flex flex-col sm:flex-row gap-4">
               <Link
                 to="/dashboard"
                 className="inline-flex items-center justify-center gap-2 px-8 py-4 bg-accent text-white rounded-xl font-semibold text-lg hover:bg-accent-hover transition-colors shadow-lg shadow-accent/25"
               >
-                Start Studying Free
+                Start Studying Now
                 <ArrowRight className="w-5 h-5" />
               </Link>
             </div>
@@ -357,7 +357,7 @@ export default function Home() {
       <section className="py-20 px-6 bg-surface-secondary border-t border-border">
         <div className="max-w-3xl mx-auto text-center">
           <h2 className="text-3xl font-bold text-text-primary mb-4">
-            Start Passing — It's Free
+            Start Passing — Today
           </h2>
           <p className="text-text-secondary mb-8">
             Jump into the dashboard and begin working through the 2026 curriculum today.
@@ -366,7 +366,7 @@ export default function Home() {
             to="/dashboard"
             className="inline-flex items-center gap-2 px-8 py-4 bg-accent text-white rounded-xl font-semibold text-lg hover:bg-accent-hover transition-colors shadow-lg shadow-accent/25"
           >
-            Start Studying Free
+            Start Studying Now
             <ArrowRight className="w-5 h-5" />
           </Link>
           <p className="text-text-muted text-sm mt-4">


### PR DESCRIPTION
## Summary
- Lock all premium content behind a gate — only **Quantitative Methods** is accessible to free users
- Remove all "free" messaging from the landing page to prepare for subscription model
- Add lock icons and dimmed styling across sidebar, dashboard cards, and quick links
- Locked routes (modules, formulas, connections, practice exam) show a premium overlay

## Test plan
- [ ] Visit dashboard — only Quantitative Methods card should be fully styled, rest show 🔒
- [ ] Click a locked subject — should see LockedOverlay instead of module content
- [ ] Navigate to /dashboard/formulas, /dashboard/connections, /dashboard/practice-exam — all show locked overlay
- [ ] Sidebar shows lock icons on non-quants subjects and quick links
- [ ] All Quantitative Methods modules (cheat sheet, mind map, flashcards, quiz) work normally
- [ ] Landing page has no "free" text

Closes #26, closes #27

🤖 Generated with [Claude Code](https://claude.com/claude-code)