### PR TITLE
Add study progress tracker with daily logging and charts

### DIFF
--- a/app/components/StudyHeatmap.jsx
+++ b/app/components/StudyHeatmap.jsx
@@ -1,0 +1,133 @@
+function buildHeatmapData(studyLogs) {
+  const hoursMap = Object.fromEntries(
+    (studyLogs || []).map((l) => [l.date, l.hours])
+  );
+
+  const today = new Date();
+  const todayDay = today.getDay(); // 0=Sun, 1=Mon...
+  // End of grid = this Saturday (end of current week)
+  const endOffset = todayDay === 0 ? 0 : 6 - todayDay; // days until Saturday
+  const endDate = new Date(today);
+  endDate.setDate(endDate.getDate() + endOffset);
+
+  // 12 weeks = 84 days
+  const startDate = new Date(endDate);
+  startDate.setDate(startDate.getDate() - 83);
+
+  const cells = [];
+  for (let i = 0; i < 84; i++) {
+    const d = new Date(startDate);
+    d.setDate(d.getDate() + i);
+    const dateStr = d.toLocaleDateString("en-CA");
+    const isFuture = d > today;
+    cells.push({
+      date: dateStr,
+      hours: isFuture ? null : hoursMap[dateStr] || 0,
+      dayOfWeek: d.getDay(),
+      month: d.getMonth(),
+    });
+  }
+  return cells;
+}
+
+function getOpacity(hours) {
+  if (hours === null) return 0.05;
+  if (hours === 0) return 1; // for the empty color
+  if (hours <= 1) return 0.35;
+  if (hours <= 2) return 0.55;
+  if (hours <= 3) return 0.8;
+  return 1;
+}
+
+const DAY_LABELS = ["S", "M", "T", "W", "T", "F", "S"];
+const MONTH_NAMES = ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"];
+
+export default function StudyHeatmap({ studyLogs }) {
+  const cells = buildHeatmapData(studyLogs);
+  const cellSize = 13;
+  const cellGap = 2;
+  const leftMargin = 18;
+  const topMargin = 16;
+  const totalWidth = leftMargin + 12 * (cellSize + cellGap);
+  const totalHeight = topMargin + 7 * (cellSize + cellGap);
+
+  // Month labels — find where months change
+  const monthLabels = [];
+  for (let col = 0; col < 12; col++) {
+    const cellIndex = col * 7;
+    if (cellIndex < cells.length) {
+      const month = cells[cellIndex].month;
+      if (col === 0 || cells[(col - 1) * 7]?.month !== month) {
+        monthLabels.push({
+          col,
+          label: MONTH_NAMES[month],
+        });
+      }
+    }
+  }
+
+  return (
+    <svg
+      viewBox={`0 0 ${totalWidth} ${totalHeight}`}
+      className="w-full"
+      role="img"
+      aria-label="Study activity heatmap"
+    >
+      {/* Month labels */}
+      {monthLabels.map(({ col, label }) => (
+        <text
+          key={`month-${col}`}
+          x={leftMargin + col * (cellSize + cellGap)}
+          y={10}
+          fill="var(--color-text-muted)"
+          style={{ fontSize: "8px" }}
+        >
+          {label}
+        </text>
+      ))}
+
+      {/* Day labels */}
+      {[1, 3, 5].map((day) => (
+        <text
+          key={`day-${day}`}
+          x={0}
+          y={topMargin + day * (cellSize + cellGap) + cellSize - 3}
+          fill="var(--color-text-muted)"
+          style={{ fontSize: "8px" }}
+        >
+          {DAY_LABELS[day]}
+        </text>
+      ))}
+
+      {/* Cells */}
+      {cells.map((cell, i) => {
+        const col = Math.floor(i / 7);
+        const row = i % 7;
+        const x = leftMargin + col * (cellSize + cellGap);
+        const y = topMargin + row * (cellSize + cellGap);
+        const isStudied = cell.hours !== null && cell.hours > 0;
+
+        return (
+          <rect
+            key={i}
+            x={x}
+            y={y}
+            width={cellSize}
+            height={cellSize}
+            rx={2.5}
+            fill={
+              isStudied
+                ? "var(--color-accent)"
+                : "var(--color-surface-tertiary)"
+            }
+            opacity={isStudied ? getOpacity(cell.hours) : cell.hours === null ? 0.3 : 1}
+          >
+            <title>
+              {cell.date}: {cell.hours === null ? "—" : `${cell.hours}h`}
+            </title>
+          </rect>
+        );
+      })}
+    </svg>
+  );
+}

--- a/app/components/StudyLogInput.jsx
+++ b/app/components/StudyLogInput.jsx
@@ -1,0 +1,116 @@
+import { useState } from "react";
+import { Flame } from "lucide-react";
+
+function getToday() {
+  return new Date().toLocaleDateString("en-CA"); // YYYY-MM-DD in local time
+}
+
+function calculateStreak(studyLogs) {
+  if (!studyLogs || studyLogs.length === 0) return 0;
+
+  const sorted = [...studyLogs]
+    .filter((l) => l.hours > 0)
+    .sort((a, b) => b.date.localeCompare(a.date));
+
+  if (sorted.length === 0) return 0;
+
+  const today = getToday();
+  const yesterday = new Date(Date.now() - 86400000).toLocaleDateString("en-CA");
+
+  // Streak must include today or yesterday
+  if (sorted[0].date !== today && sorted[0].date !== yesterday) return 0;
+
+  let streak = 1;
+  for (let i = 1; i < sorted.length; i++) {
+    const prevDay = new Date(sorted[i - 1].date + "T00:00:00");
+    const currDay = new Date(sorted[i].date + "T00:00:00");
+    const diffDays = (prevDay - currDay) / 86400000;
+    if (diffDays === 1) {
+      streak++;
+    } else {
+      break;
+    }
+  }
+  return streak;
+}
+
+export default function StudyLogInput({ studyLogs, setStudyLogs }) {
+  const today = getToday();
+  const [inputHours, setInputHours] = useState("");
+  const [inputDate, setInputDate] = useState(today);
+
+  const selectedLog = studyLogs.find((l) => l.date === inputDate);
+  const streak = calculateStreak(studyLogs);
+  const totalHours = studyLogs.reduce((sum, l) => sum + (l.hours || 0), 0);
+  const daysStudied = studyLogs.filter((l) => l.hours > 0).length;
+  const avgHours = daysStudied > 0 ? Math.round((totalHours / daysStudied) * 10) / 10 : 0;
+  const todayLog = studyLogs.find((l) => l.date === today);
+
+  function handleLog() {
+    const hours = parseFloat(inputHours);
+    if (isNaN(hours) || hours <= 0) return;
+
+    // Upsert: replace existing entry for selected date
+    const updated = studyLogs.filter((l) => l.date !== inputDate);
+    updated.push({ date: inputDate, hours });
+    setStudyLogs(updated);
+    setInputHours("");
+  }
+
+  return (
+    <div>
+      <h3 className="text-sm font-semibold text-text-primary mb-4">
+        Log Study Hours
+      </h3>
+
+      {/* Stats row */}
+      <div className="flex items-center gap-3 mb-4 flex-wrap">
+        <div className="flex items-center gap-1.5 bg-orange-500/10 text-orange-400 rounded-lg px-3 py-1.5 text-sm font-semibold">
+          <Flame size={16} />
+          {streak} day{streak !== 1 ? "s" : ""}
+        </div>
+        <div className="text-xs text-text-muted">
+          {Math.round(totalHours * 10) / 10}h total
+        </div>
+        <div className="text-xs text-text-muted">
+          {avgHours}h/day avg
+        </div>
+      </div>
+
+      {/* Today's status */}
+      {todayLog && (
+        <p className="text-sm text-success mb-3">
+          Today: {todayLog.hours}h logged
+        </p>
+      )}
+
+      {/* Input row */}
+      <div className="flex gap-2">
+        <input
+          type="date"
+          max={today}
+          value={inputDate}
+          onChange={(e) => setInputDate(e.target.value)}
+          className="bg-surface-tertiary border border-border rounded-lg px-2 py-2 text-sm text-text-primary focus:outline-none focus:border-accent/50"
+        />
+        <input
+          type="number"
+          min="0"
+          max="24"
+          step="0.5"
+          value={inputHours}
+          onChange={(e) => setInputHours(e.target.value)}
+          onKeyDown={(e) => e.key === "Enter" && handleLog()}
+          placeholder={selectedLog ? `${selectedLog.hours}h logged` : "Hours"}
+          className="flex-1 min-w-0 bg-surface-tertiary border border-border rounded-lg px-3 py-2 text-sm text-text-primary placeholder:text-text-muted focus:outline-none focus:border-accent/50"
+        />
+        <button
+          onClick={handleLog}
+          className="px-4 py-2 bg-accent text-white rounded-lg text-sm font-medium hover:bg-accent/90 transition-colors shrink-0"
+        >
+          Log
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/app/components/WeeklyBarChart.jsx
+++ b/app/components/WeeklyBarChart.jsx
@@ -1,0 +1,87 @@
+function getLast7Days() {
+  const days = [];
+  for (let i = 6; i >= 0; i--) {
+    const d = new Date(Date.now() - i * 86400000);
+    days.push(d.toLocaleDateString("en-CA"));
+  }
+  return days;
+}
+
+function formatDayLabel(dateStr) {
+  const d = new Date(dateStr + "T00:00:00");
+  return d.toLocaleDateString("en-US", { weekday: "short" }).slice(0, 3);
+}
+
+export default function WeeklyBarChart({ studyLogs }) {
+  const days = getLast7Days();
+  const hoursMap = Object.fromEntries(
+    (studyLogs || []).map((l) => [l.date, l.hours])
+  );
+  const data = days.map((d) => ({ date: d, hours: hoursMap[d] || 0 }));
+  const maxHours = Math.max(4, ...data.map((d) => d.hours));
+
+  const barWidth = 28;
+  const gap = 12;
+  const chartHeight = 90;
+  const totalWidth = 7 * barWidth + 6 * gap;
+
+  return (
+    <svg
+      viewBox={`0 0 ${totalWidth} 130`}
+      className="w-full"
+      role="img"
+      aria-label="Weekly study hours bar chart"
+    >
+      {data.map((d, i) => {
+        const barHeight = (d.hours / maxHours) * chartHeight;
+        const x = i * (barWidth + gap);
+        const y = chartHeight - barHeight;
+        const isToday = d.date === new Date().toLocaleDateString("en-CA");
+
+        return (
+          <g key={d.date}>
+            {/* Bar */}
+            <rect
+              x={x}
+              y={d.hours > 0 ? y : chartHeight - 3}
+              width={barWidth}
+              height={d.hours > 0 ? barHeight : 3}
+              rx={4}
+              fill="var(--color-accent)"
+              opacity={d.hours > 0 ? 1 : 0.15}
+            />
+            {/* Hours label */}
+            {d.hours > 0 && (
+              <text
+                x={x + barWidth / 2}
+                y={y - 6}
+                textAnchor="middle"
+                fill="var(--color-text-primary)"
+                style={{ fontSize: "11px", fontWeight: 600 }}
+              >
+                {d.hours}h
+              </text>
+            )}
+            {/* Day label */}
+            <text
+              x={x + barWidth / 2}
+              y={chartHeight + 16}
+              textAnchor="middle"
+              fill={
+                isToday
+                  ? "var(--color-accent)"
+                  : "var(--color-text-muted)"
+              }
+              style={{
+                fontSize: "11px",
+                fontWeight: isToday ? 700 : 400,
+              }}
+            >
+              {formatDayLabel(d.date)}
+            </text>
+          </g>
+        );
+      })}
+    </svg>
+  );
+}

--- a/app/routes/dashboard-index.jsx
+++ b/app/routes/dashboard-index.jsx
@@ -3,10 +3,13 @@ import { Link, useSearchParams } from "react-router";
 import { subjects, allModules, isContentLocked } from "~/data";
 import { useAuth } from "~/context/AuthContext";
 import { useDashboardContext } from "./dashboard";
+import StudyLogInput from "~/components/StudyLogInput";
+import WeeklyBarChart from "~/components/WeeklyBarChart";
+import StudyHeatmap from "~/components/StudyHeatmap";
 
 export default function DashboardIndex() {
   const { isPremium, refreshSubscription } = useAuth();
-  const { progress } = useDashboardContext();
+  const { progress, studyLogs, setStudyLogs } = useDashboardContext();
   const [searchParams, setSearchParams] = useSearchParams();
   const [checkoutSuccess, setCheckoutSuccess] = useState(false);
 
@@ -79,6 +82,21 @@ export default function DashboardIndex() {
           color="text-warning"
         />
         <StatCard label="Progress" value={`${overallPercent}%`} color="text-accent" />
+      </div>
+
+      {/* Study Progress */}
+      <div className="grid grid-cols-1 lg:grid-cols-3 gap-4 mb-8">
+        <div className="bg-surface-secondary rounded-xl border border-border p-6">
+          <StudyLogInput studyLogs={studyLogs} setStudyLogs={setStudyLogs} />
+        </div>
+        <div className="bg-surface-secondary rounded-xl border border-border p-6">
+          <h3 className="text-sm font-semibold text-text-primary mb-4">This Week</h3>
+          <WeeklyBarChart studyLogs={studyLogs} />
+        </div>
+        <div className="bg-surface-secondary rounded-xl border border-border p-6">
+          <h3 className="text-sm font-semibold text-text-primary mb-4">Study Activity</h3>
+          <StudyHeatmap studyLogs={studyLogs} />
+        </div>
       </div>
 
       {/* Progress Round Chart */}

--- a/app/routes/dashboard.jsx
+++ b/app/routes/dashboard.jsx
@@ -12,6 +12,7 @@ export default function DashboardLayout() {
   const [sidebarOpen, setSidebarOpen] = useState(false);
   const [progress, setProgress] = useState({});
   const [quizScores, setQuizScores] = useState([]);
+  const [studyLogs, setStudyLogs] = useState([]);
   const [loaded, setLoaded] = useState(false);
   const params = useParams();
 
@@ -23,6 +24,7 @@ export default function DashboardLayout() {
         const data = snap.data();
         if (data.progress) setProgress(data.progress);
         if (data.quizScores) setQuizScores(data.quizScores);
+        if (data.studyLogs) setStudyLogs(data.studyLogs);
       }
       setLoaded(true);
     });
@@ -35,6 +37,19 @@ export default function DashboardLayout() {
         const next = typeof updater === "function" ? updater(prev) : updater;
         if (user && loaded) {
           updateDoc(doc(db, "users", user.uid), { progress: next });
+        }
+        return next;
+      });
+    },
+    [user, loaded]
+  );
+
+  const setStudyLogsAndSync = useCallback(
+    (updater) => {
+      setStudyLogs((prev) => {
+        const next = typeof updater === "function" ? updater(prev) : updater;
+        if (user && loaded) {
+          updateDoc(doc(db, "users", user.uid), { studyLogs: next });
         }
         return next;
       });
@@ -73,7 +88,7 @@ export default function DashboardLayout() {
 
       <main className="pt-16 lg:ml-72 min-h-screen flex flex-col">
         <div className="flex-1">
-          <Outlet context={{ progress, setProgress: setProgressAndSync, quizScores, setQuizScores }} />
+          <Outlet context={{ progress, setProgress: setProgressAndSync, quizScores, setQuizScores, studyLogs, setStudyLogs: setStudyLogsAndSync }} />
         </div>
         <footer className="px-6 py-4 text-center text-[11px] text-text-muted border-t border-border">
           CFA® is a registered trademark owned by CFA Institute. CFA-Master is not affiliated with or endorsed by CFA Institute.


### PR DESCRIPTION
## Summary
- **StudyLogInput**: Log study hours for any date (past or today), view streak counter, total hours, and avg hrs/day
- **WeeklyBarChart**: Pure SVG bar chart showing last 7 days of study hours with today highlighted
- **StudyHeatmap**: Pure SVG 12-week GitHub-style contribution heatmap with intensity-based coloring
- **Firestore integration**: `studyLogs` array persisted in user doc via dashboard context (same pattern as progress/quizScores)

Closes #5

## Test plan
- [ ] Log hours for today — verify bar chart and heatmap update
- [ ] Log hours for a past date via date picker — verify charts reflect it
- [ ] Log hours on consecutive days — verify streak counter increments
- [ ] Refresh page — verify data persists from Firestore
- [ ] Check avg hrs/day and total hours stats are accurate
- [ ] Test mobile layout — cards should stack vertically

🤖 Generated with [Claude Code](https://claude.com/claude-code)