### PR TITLE
Add Meta Pixel conversion events

### DIFF
--- a/app/components/Quiz.jsx
+++ b/app/components/Quiz.jsx
@@ -1,4 +1,5 @@
 import { useState, useCallback } from "react";
+import { trackCustomEvent } from "~/lib/analytics";
 
 const OPTION_LABELS = ["A", "B", "C", "D"];
 
@@ -41,6 +42,14 @@ export default function Quiz({ questions, onScoreSubmit, previousScores = [] }) 
     if (onScoreSubmit) {
       onScoreSubmit({ score: finalScore, total: questions.length });
     }
+
+    const isPracticeExam = questions.length >= 100;
+    const pct = Math.round((finalScore / questions.length) * 100);
+    trackCustomEvent(isPracticeExam ? "PracticeExamCompleted" : "QuizSubmitted", {
+      score: finalScore,
+      total: questions.length,
+      percentage: pct,
+    });
   }, [answers, questions, onScoreSubmit]);
 
   const handleReset = useCallback(() => {

--- a/app/components/StudyLogInput.jsx
+++ b/app/components/StudyLogInput.jsx
@@ -1,5 +1,6 @@
 import { useState } from "react";
 import { Flame } from "lucide-react";
+import { trackCustomEvent } from "~/lib/analytics";
 
 function getToday() {
   return new Date().toLocaleDateString("en-CA"); // YYYY-MM-DD in local time
@@ -55,6 +56,8 @@ export default function StudyLogInput({ studyLogs, setStudyLogs }) {
     updated.push({ date: inputDate, hours });
     setStudyLogs(updated);
     setInputHours("");
+
+    trackCustomEvent("StudyHoursLogged", { hours, date: inputDate });
   }
 
   return (

--- a/app/lib/analytics.js
+++ b/app/lib/analytics.js
@@ -1,0 +1,22 @@
+/**
+ * Unified analytics helper — fires events to all configured providers.
+ * Currently supports: Meta Pixel (fbq)
+ * Add Google Analytics (gtag), etc. here in the future.
+ */
+
+function getFbq() {
+  if (typeof window !== "undefined" && window.fbq) return window.fbq;
+  return null;
+}
+
+/** Fire a standard event (e.g. Purchase, Lead, ViewContent) */
+export function trackEvent(eventName, params = {}) {
+  const fbq = getFbq();
+  if (fbq) fbq("track", eventName, params);
+}
+
+/** Fire a custom event (e.g. QuizSubmitted, ModuleCompleted) */
+export function trackCustomEvent(eventName, params = {}) {
+  const fbq = getFbq();
+  if (fbq) fbq("trackCustom", eventName, params);
+}

--- a/app/routes/dashboard-index.jsx
+++ b/app/routes/dashboard-index.jsx
@@ -2,6 +2,7 @@ import { useState, useEffect } from "react";
 import { Link, useSearchParams } from "react-router";
 import { subjects, allModules, isContentLocked } from "~/data";
 import { useAuth } from "~/context/AuthContext";
+import { trackCustomEvent } from "~/lib/analytics";
 import { useDashboardContext } from "./dashboard";
 import StudyLogInput from "~/components/StudyLogInput";
 import WeeklyBarChart from "~/components/WeeklyBarChart";
@@ -179,6 +180,11 @@ export default function DashboardIndex() {
             <Link
               key={subject.id}
               to={`/dashboard/${subject.id}/${subject.modules[0]?.id}`}
+              onClick={() => {
+                if (locked) {
+                  trackCustomEvent("PremiumContentBlocked", { content_name: subject.name, content_type: "subject" });
+                }
+              }}
               className={`group block bg-surface-secondary rounded-xl p-5 border border-border transition-all ${locked ? "opacity-60" : "hover:border-accent/50 hover:shadow-lg"}`}
             >
               <div className="flex items-start justify-between mb-3">
@@ -263,6 +269,11 @@ function QuickLink({ to, icon, title, desc, locked }) {
   return (
     <Link
       to={to}
+      onClick={() => {
+        if (locked) {
+          trackCustomEvent("PremiumContentBlocked", { content_name: title });
+        }
+      }}
       className={`flex items-center gap-4 bg-surface-secondary rounded-xl p-4 border border-border transition-all group ${locked ? "opacity-60" : "hover:border-accent/50 hover:shadow-lg"}`}
     >
       <span className="text-3xl">{icon}</span>

--- a/app/routes/dashboard-module.jsx
+++ b/app/routes/dashboard-module.jsx
@@ -10,6 +10,7 @@ import MindMap from "~/components/MindMap";
 import FlashCards from "~/components/FlashCards";
 import Quiz from "~/components/Quiz";
 import LockedOverlay from "~/components/LockedOverlay";
+import { trackCustomEvent } from "~/lib/analytics";
 
 const TABS = [
   { id: "cheatsheet", label: "Cheat Sheet", icon: "📋" },
@@ -55,10 +56,19 @@ export default function DashboardModule() {
   );
 
   const toggleComplete = () => {
+    const wasCompleted = progress[progressKey];
     setProgress((prev) => ({
       ...prev,
       [progressKey]: !prev[progressKey],
     }));
+    if (!wasCompleted) {
+      trackCustomEvent("ModuleCompleted", {
+        module_id: moduleId,
+        subject_id: subjectId,
+        module_name: mod?.title,
+        subject_name: subject?.name,
+      });
+    }
   };
 
   if (loading) {

--- a/app/routes/home.jsx
+++ b/app/routes/home.jsx
@@ -1,6 +1,7 @@
 import { Link } from "react-router";
 import { subjects, allModules } from "~/data";
 import { useTheme } from "~/context/ThemeContext";
+import { trackEvent } from "~/lib/analytics";
 import {
   Sun,
   Moon,
@@ -115,6 +116,9 @@ export default function Home() {
             <div className="flex flex-col sm:flex-row gap-4">
               <Link
                 to="/dashboard"
+                onClick={() => {
+                  trackEvent("Lead", { content_name: "Hero CTA" });
+                }}
                 className="inline-flex items-center justify-center gap-2 px-8 py-4 bg-accent text-white rounded-xl font-semibold text-lg hover:bg-accent-hover transition-colors shadow-lg shadow-accent/25"
               >
                 Start Studying Now
@@ -359,6 +363,9 @@ export default function Home() {
           </p>
           <Link
             to="/dashboard"
+            onClick={() => {
+              trackEvent("Lead", { content_name: "Footer CTA" });
+            }}
             className="inline-flex items-center gap-2 px-8 py-4 bg-accent text-white rounded-xl font-semibold text-lg hover:bg-accent-hover transition-colors shadow-lg shadow-accent/25"
           >
             Start Studying Now

--- a/app/routes/login.jsx
+++ b/app/routes/login.jsx
@@ -1,6 +1,7 @@
 import { useState } from "react";
 import { Navigate } from "react-router";
 import { useAuth } from "~/context/AuthContext";
+import { trackEvent, trackCustomEvent } from "~/lib/analytics";
 
 
 export default function Login() {
@@ -27,8 +28,11 @@ export default function Login() {
     try {
       if (isSignUp) {
         await signUpWithEmail(email, password);
+        trackEvent("CompleteRegistration", { content_name: "Email Sign Up", status: true });
+        trackCustomEvent("SignUp", { method: "email" });
       } else {
         await signInWithEmail(email, password);
+        trackCustomEvent("Login", { method: "email" });
       }
     } catch (err) {
       setError(err.message.replace("Firebase: ", ""));
@@ -39,6 +43,8 @@ export default function Login() {
     setError("");
     try {
       await signInWithGoogle();
+      trackEvent("CompleteRegistration", { content_name: "Google Sign In", status: true });
+      trackCustomEvent("Login", { method: "google" });
     } catch (err) {
       setError(err.message.replace("Firebase: ", ""));
     }

--- a/app/routes/pricing.jsx
+++ b/app/routes/pricing.jsx
@@ -1,7 +1,8 @@
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { Link, useNavigate } from "react-router";
 import { useTheme } from "~/context/ThemeContext";
 import { useAuth } from "~/context/AuthContext";
+import { trackEvent } from "~/lib/analytics";
 import { Sun, Moon, Check, ArrowLeft, Loader2 } from "lucide-react";
 
 const freeFeatures = [
@@ -29,6 +30,16 @@ export default function Pricing() {
   const [loading, setLoading] = useState(false);
   const navigate = useNavigate();
 
+  useEffect(() => {
+    trackEvent("ViewContent", {
+      content_name: "Pricing Page",
+      content_type: "product",
+      content_ids: ["cfa-premium"],
+      currency: "INR",
+      value: 2999,
+    });
+  }, []);
+
   async function handlePayment() {
     if (!user) {
       navigate("/login");
@@ -36,6 +47,13 @@ export default function Pricing() {
     }
 
     setLoading(true);
+    trackEvent("InitiateCheckout", {
+      content_ids: ["cfa-premium"],
+      content_type: "product",
+      currency: "INR",
+      value: 2999,
+      num_items: 1,
+    });
     try {
       const orderRes = await fetch("/api/razorpay-order", {
         method: "POST",
@@ -74,6 +92,14 @@ export default function Pricing() {
           });
 
           if (verifyRes.ok) {
+            trackEvent("Purchase", {
+              content_ids: ["cfa-premium"],
+              content_name: "CFA Master Premium",
+              content_type: "product",
+              currency: "INR",
+              value: 2999,
+              num_items: 1,
+            });
             await auth.refreshSubscription();
             navigate("/payment-success");
           } else {


### PR DESCRIPTION
## Summary
- Adds 12 Meta Pixel events across 7 files for conversion tracking and engagement analytics
- Introduces a unified `app/lib/analytics.js` helper (`trackEvent`/`trackCustomEvent`) so Google Analytics and other providers can be added in one place later
- All SSR-safe with window guards centralized in the helper

## Events Added

### Standard Events (fbq track)
- **Purchase** — after payment verification on pricing page
- **CompleteRegistration** — after Google or email signup
- **InitiateCheckout** — when user clicks "Get Premium"
- **ViewContent** — on pricing page load
- **Lead** — on "Start Studying Now" CTA clicks (hero + footer)

### Custom Events (fbq trackCustom)
- **Login** — on sign-in (email or Google)
- **SignUp** — on email registration
- **QuizSubmitted** — on module quiz submission with score
- **PracticeExamCompleted** — on practice exam submission (100+ questions)
- **ModuleCompleted** — when user marks a module complete
- **StudyHoursLogged** — when study hours are logged
- **PremiumContentBlocked** — when free user clicks locked content

## Test plan
- [ ] Verify build passes (confirmed locally)
- [ ] Test Meta Pixel events fire correctly using Facebook Pixel Helper browser extension
- [ ] Confirm no SSR errors on page load

Closes #38

🤖 Generated with [Claude Code](https://claude.com/claude-code)